### PR TITLE
Build task: Ensure main() is invoked

### DIFF
--- a/tasks/build/build_action.js
+++ b/tasks/build/build_action.js
@@ -80,4 +80,7 @@ module.exports = function (plugin) {
       .pipe(zip(`${buildId}.zip`))
       .pipe(vfs.dest(join(plugin.root, 'build')));
   }
+
+  main();
+
 };


### PR DESCRIPTION
I've filed this as a separate pull request because I'm not sure if there's a better / more idiomatic way to make the calling script aware that it needs to call an extra function. This just automatically invokes main() on any run of the module.