### PR TITLE
Running main, corrected build, checking for no dependencies

### DIFF
--- a/tasks/build/build_action.js
+++ b/tasks/build/build_action.js
@@ -52,7 +52,7 @@ module.exports = function (plugin) {
 
     if (deps.length === 1) {
       files.push(`node_modules/${ deps[0] }/**/*`);
-    } else {
+    } else if(deps.length) {
       files.push(`node_modules/{${ deps.join(',') }}/**/*`);
     }
 

--- a/tasks/build/build_action.js
+++ b/tasks/build/build_action.js
@@ -80,4 +80,6 @@ module.exports = function (plugin) {
       .pipe(zip(`${buildId}.zip`))
       .pipe(vfs.dest(join(plugin.root, 'build')));
   }
+
+  main();
 };

--- a/tasks/build/build_action.js
+++ b/tasks/build/build_action.js
@@ -43,7 +43,7 @@ module.exports = function (plugin) {
     }
   }
 
-  function build(deps, kibanaVersion) {
+  function build(buildId, deps, kibanaVersion) {
     var files = [
       'package.json',
       'index.js',


### PR DESCRIPTION
I had 3 issues with the -pre3 release:

1. I had 0 dependencies, so the added if check was unneeded
2. The build "main()" function was never run so the builds wouldn't run
3. The build function was getting 3 parameters sent to it, but only expected 2 (thus the length of deps was around 34 in my case when it should have been 0)