### PR TITLE
Add test task

### DIFF
--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -32,6 +32,7 @@ program
 
 program
   .command('test:browser')
+  .option('--dev', 'Enable dev mode, keeps the test server running')
   .description('Run the browser tests in a real web browser')
   .on('--help', docs('test/browser'))
   .action(run('test/browser'));

--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -25,6 +25,12 @@ program
   .action(run('build'));
 
 program
+  .command('test')
+  .description('Run the server and browser tests')
+  .on('--help', docs('test/all'))
+  .action(run('test/all'));
+
+program
   .command('test:browser')
   .description('Run the browser tests in a real web browser')
   .on('--help', docs('test/browser'))

--- a/lib/run.js
+++ b/lib/run.js
@@ -6,6 +6,6 @@ module.exports = function run(name) {
     // call the action function with the plugin, then all
     // renaining arguments from commander
     var plugin = pluginConfig();
-    action.apply(null, [plugin].concat([].slice.apply(arguments)));
+    action.apply(null, [plugin, run].concat([].slice.apply(arguments)));
   };
 };

--- a/tasks/start/start_action.js
+++ b/tasks/start/start_action.js
@@ -2,7 +2,12 @@ module.exports = function (plugin, command) {
   var execFileSync = require('child_process').execFileSync;
 
   var cmd = (process.platform === 'win32') ? 'bin\\kibana.bat' : 'bin/kibana';
-  var args = ['--dev', '--plugin-path', plugin.root, ...command.unkownOptions];
+  var args = ['--dev', '--plugin-path', plugin.root];
+
+  if (command.unkownOptions) {
+    args = args.concat(command.unkownOptions);
+  }
+
   execFileSync(cmd, args, {
     cwd: plugin.kibanaRoot,
     stdio: ['ignore', 1, 2]

--- a/tasks/start/start_action.js
+++ b/tasks/start/start_action.js
@@ -1,4 +1,4 @@
-module.exports = function (plugin, command) {
+module.exports = function (plugin, run, command) {
   var execFileSync = require('child_process').execFileSync;
 
   var cmd = (process.platform === 'win32') ? 'bin\\kibana.bat' : 'bin/kibana';

--- a/tasks/test/all/README.md
+++ b/tasks/test/all/README.md
@@ -1,0 +1,3 @@
+Runs both the server and browser tests, in that order. 
+
+This is just a simple caller to both `test/server` and `test/browser`

--- a/tasks/test/all/index.js
+++ b/tasks/test/all/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./test_all_action');

--- a/tasks/test/all/test_all_action.js
+++ b/tasks/test/all/test_all_action.js
@@ -1,6 +1,4 @@
-var run = require('../../../lib/run');
-
-module.exports = function testAllAction(plugin) {
+module.exports = function testAllAction(plugin, run) {
   run('test/server').call(null);
   run('test/browser').call(null, { runOnce: true });
 };

--- a/tasks/test/all/test_all_action.js
+++ b/tasks/test/all/test_all_action.js
@@ -1,0 +1,6 @@
+var run = require('../../../lib/run');
+
+module.exports = function testAllAction(plugin) {
+  run('test/server').call(null);
+  run('test/browser').call(null, { runOnce: true });
+};

--- a/tasks/test/all/test_all_action.js
+++ b/tasks/test/all/test_all_action.js
@@ -1,4 +1,4 @@
 module.exports = function testAllAction(plugin, run) {
-  run('test/server').call(null);
-  run('test/browser').call(null);
+  run('test/server')();
+  run('test/browser')();
 };

--- a/tasks/test/all/test_all_action.js
+++ b/tasks/test/all/test_all_action.js
@@ -1,4 +1,4 @@
 module.exports = function testAllAction(plugin, run) {
   run('test/server').call(null);
-  run('test/browser').call(null, { runOnce: true });
+  run('test/browser').call(null);
 };

--- a/tasks/test/browser/test_browser_action.js
+++ b/tasks/test/browser/test_browser_action.js
@@ -1,4 +1,4 @@
-module.exports = function (plugin) {
+module.exports = function (plugin, opts = {}) {
   var execFileSync = require('child_process').execFileSync;
 
   var kbnServerArgs = [
@@ -7,7 +7,8 @@ module.exports = function (plugin) {
   ];
 
   var cmd = 'npm';
-  var args = ['run', 'test:dev', '--'].concat(kbnServerArgs);
+  var task = (opts.runOnce) ? 'test:browser' : 'test:dev';
+  var args = ['run', task, '--'].concat(kbnServerArgs);
   execFileSync(cmd, args, {
     cwd: plugin.kibanaRoot,
     stdio: ['ignore', 1, 2]

--- a/tasks/test/browser/test_browser_action.js
+++ b/tasks/test/browser/test_browser_action.js
@@ -1,6 +1,5 @@
-module.exports = function testBrowserAction(plugin, run, opts) {
+module.exports = function testBrowserAction(plugin, run, command) {
   var execFileSync = require('child_process').execFileSync;
-  opts = opts || {};
 
   var kbnServerArgs = [
     '--kbnServer.testsBundle.pluginId=' + plugin.id,
@@ -8,7 +7,7 @@ module.exports = function testBrowserAction(plugin, run, opts) {
   ];
 
   var cmd = 'npm';
-  var task = (opts.runOnce) ? 'test:browser' : 'test:dev';
+  var task = (command.dev) ? 'test:dev' : 'test:browser';
   var args = ['run', task, '--'].concat(kbnServerArgs);
   execFileSync(cmd, args, {
     cwd: plugin.kibanaRoot,

--- a/tasks/test/browser/test_browser_action.js
+++ b/tasks/test/browser/test_browser_action.js
@@ -1,5 +1,6 @@
-module.exports = function (plugin, opts = {}) {
+module.exports = function testBrowserAction(plugin, run, opts) {
   var execFileSync = require('child_process').execFileSync;
+  opts = opts || {};
 
   var kbnServerArgs = [
     '--kbnServer.testsBundle.pluginId=' + plugin.id,

--- a/tasks/test/browser/test_browser_action.js
+++ b/tasks/test/browser/test_browser_action.js
@@ -1,5 +1,6 @@
 module.exports = function testBrowserAction(plugin, run, command) {
   var execFileSync = require('child_process').execFileSync;
+  command = command || {};
 
   var kbnServerArgs = [
     '--kbnServer.testsBundle.pluginId=' + plugin.id,


### PR DESCRIPTION
This PR adds a test task, which simply wraps `test:server` and `test:browser`, in that order.

Uses the same `run` command internally as the commander action caller uses.