### PR TITLE
Move require calls outside of task functions

### DIFF
--- a/tasks/build/build_action.js
+++ b/tasks/build/build_action.js
@@ -1,11 +1,12 @@
+var vfs = require('vinyl-fs');
+var zip = require('gulp-zip');
+var map = require('through2-map').obj;
+var rename = require('gulp-rename');
+var join = require('path').join;
+var inquirer = require('inquirer');
+
 module.exports = function (plugin) {
   return new Promise(function (resolve, reject) {
-    var vfs = require('vinyl-fs');
-    var zip = require('gulp-zip');
-    var map = require('through2-map').obj;
-    var rename = require('gulp-rename');
-    var join = require('path').join;
-    var inquirer = require('inquirer');
 
     function main() {
       var kibanaVersion = (plugin.pkg.kibana && plugin.pkg.kibana.version) || plugin.pkg.version;

--- a/tasks/start/start_action.js
+++ b/tasks/start/start_action.js
@@ -1,3 +1,5 @@
+var execFileSync = require('child_process').execFileSync;
+
 module.exports = function (plugin, run, command) {
   var execFileSync = require('child_process').execFileSync;
 

--- a/tasks/start/start_action.js
+++ b/tasks/start/start_action.js
@@ -1,7 +1,7 @@
 var execFileSync = require('child_process').execFileSync;
 
 module.exports = function (plugin, run, command) {
-  var execFileSync = require('child_process').execFileSync;
+  command = command || {};
 
   var cmd = (process.platform === 'win32') ? 'bin\\kibana.bat' : 'bin/kibana';
   var args = ['--dev', '--plugin-path', plugin.root];

--- a/tasks/test/browser/test_browser_action.js
+++ b/tasks/test/browser/test_browser_action.js
@@ -1,5 +1,6 @@
+var execFileSync = require('child_process').execFileSync;
+
 module.exports = function testBrowserAction(plugin, run, command) {
-  var execFileSync = require('child_process').execFileSync;
   command = command || {};
 
   var kbnServerArgs = [

--- a/tasks/test/server/test_server_action.js
+++ b/tasks/test/server/test_server_action.js
@@ -1,8 +1,8 @@
-module.exports = function (plugin) {
-  var resolve = require('path').resolve;
-  var delimiter = require('path').delimiter;
-  var execFileSync = require('child_process').execFileSync;
+var resolve = require('path').resolve;
+var delimiter = require('path').delimiter;
+var execFileSync = require('child_process').execFileSync;
 
+module.exports = function (plugin) {
   var kibanaBins = resolve(plugin.kibanaRoot, 'node_modules/.bin');
   var mochaSetupJs = resolve(plugin.kibanaRoot, 'test/mocha_setup.js');
 


### PR DESCRIPTION
Follows standard node conventions, and follows the expected pattern if there are plans to move to imports.