### PR TITLE
Allow users to pass options to test runners to control which tests to run

### DIFF
--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -32,14 +32,15 @@ program
 
 program
   .command('test:browser')
-  .option('--dev', 'Enable dev mode, keeps the test server running')
   .description('Run the browser tests in a real web browser')
+  .option('--dev', 'Enable dev mode, keeps the test server running')
   .on('--help', docs('test/browser'))
   .action(run('test/browser'));
 
 program
   .command('test:server')
   .description('Run the server tests using mocha')
+  .option('-i, --include <globs>', 'Additional files of glob patterns to include server tests from')
   .on('--help', docs('test/server'))
   .action(run('test/server'));
 

--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -39,9 +39,8 @@ program
   .action(run('test/browser'));
 
 program
-  .command('test:server')
+  .command('test:server [files...]')
   .description('Run the server tests using mocha')
-  .option('-i, --include <globs>', 'Additional files of glob patterns to include server tests from')
   .on('--help', docs('test/server'))
   .action(run('test/server'));
 

--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -34,6 +34,7 @@ program
   .command('test:browser')
   .description('Run the browser tests in a real web browser')
   .option('--dev', 'Enable dev mode, keeps the test server running')
+  .option('-p, --plugins <plugin-ids>', 'Manually specify which plugins\' test bundles to run')
   .on('--help', docs('test/browser'))
   .action(run('test/browser'));
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -6,6 +6,8 @@ module.exports = function run(name) {
     // call the action function with the plugin, then all
     // renaining arguments from commander
     var plugin = pluginConfig();
-    action.apply(null, [plugin, run].concat([].slice.apply(arguments)));
+    var args = [].slice.apply(arguments);
+
+    action.apply(null, [plugin, run].concat(args));
   };
 };

--- a/tasks/test/browser/README.md
+++ b/tasks/test/browser/README.md
@@ -21,9 +21,18 @@ Browser tests are written just like server tests, they are just executed differe
 starting the test runner
 ========================
 
-Under the covers this command uses the `test:dev` task from kibana. This task sets-up
-a test runner that will watch your code for changes and rebuild your tests when necessary.
-You access the test runner through a browser that it starts itself (via Karma).
+Under the covers this command uses the `test:browser` task from kibana. This will execute
+your tasks once and exit when complete.
+
+When run with the `--dev` option, the command uses the `test:dev` task from kibana. 
+This task sets-up a test runner that will watch your code for changes and rebuild your 
+tests when necessary. You access the test runner through a browser that it starts itself 
+(via Karma).
+
+If your plugin consists of a number of internal plugins, you may wish to keep the tests
+isolated to a specific plugin or plugins, instead of executing all of the tests. To do this,
+use `--plugins` and passing the plugins you would like to test. Muliple plugins can be
+specified by separating them with commas.
 
 
 running the tests

--- a/tasks/test/browser/test_browser_action.js
+++ b/tasks/test/browser/test_browser_action.js
@@ -4,9 +4,14 @@ module.exports = function testBrowserAction(plugin, run, command) {
   command = command || {};
 
   var kbnServerArgs = [
-    '--kbnServer.testsBundle.pluginId=' + plugin.id,
     '--kbnServer.plugin-path=' + plugin.root
   ];
+
+  if (command.plugins) {
+    kbnServerArgs.push('--kbnServer.testsBundle.pluginId=' + command.plugins);
+  } else {
+    kbnServerArgs.push('--kbnServer.testsBundle.pluginId=' + plugin.id);
+  }
 
   var cmd = 'npm';
   var task = (command.dev) ? 'test:dev' : 'test:browser';

--- a/tasks/test/server/README.md
+++ b/tasks/test/server/README.md
@@ -23,6 +23,15 @@ running the tests
 Running the server tests is simple, just execute `npm run test:server` in your terminal
 and all of the tests in your server will be run.
 
+By default, the runner will look for tests in `server/**/__tests__/**/*.js`. If you'd prefer to
+use a different collection of globs and files, you can specify them after the `npm run test:server`
+task, like so:
+
+`npm run test:server 'plugins/myplugins/server/__tests__/**/*.js'`
+
+NOTE: quoting the glob pattern is not required, but helps to avoid issues with globbing expansion
+in your shell.
+
 
 focus on the task at hand
 =========================

--- a/tasks/test/server/test_server_action.js
+++ b/tasks/test/server/test_server_action.js
@@ -2,13 +2,21 @@ var resolve = require('path').resolve;
 var delimiter = require('path').delimiter;
 var execFileSync = require('child_process').execFileSync;
 
-module.exports = function (plugin) {
+module.exports = function (plugin, run, command) {
+  command = command || {};
+
   var kibanaBins = resolve(plugin.kibanaRoot, 'node_modules/.bin');
   var mochaSetupJs = resolve(plugin.kibanaRoot, 'test/mocha_setup.js');
 
   var cmd = 'mocha';
   var args = ['--require', mochaSetupJs, 'server/**/__tests__/**/*.js'];
   var path = `${kibanaBins}${delimiter}${process.env.PATH}`;
+
+  if (command.include) {
+    var globs = command.include.split(',');
+    args = args.concat(globs);
+  }
+
   execFileSync(cmd, args, {
     cwd: plugin.root,
     stdio: ['ignore', 1, 2],

--- a/tasks/test/server/test_server_action.js
+++ b/tasks/test/server/test_server_action.js
@@ -2,20 +2,14 @@ var resolve = require('path').resolve;
 var delimiter = require('path').delimiter;
 var execFileSync = require('child_process').execFileSync;
 
-module.exports = function (plugin, run, command) {
-  command = command || {};
-
+module.exports = function (plugin, run, files) {
   var kibanaBins = resolve(plugin.kibanaRoot, 'node_modules/.bin');
   var mochaSetupJs = resolve(plugin.kibanaRoot, 'test/mocha_setup.js');
 
   var cmd = 'mocha';
-  var args = ['--require', mochaSetupJs, 'server/**/__tests__/**/*.js'];
+  var testPaths = (files.length) ? files : 'server/**/__tests__/**/*.js';
+  var args = ['--require', mochaSetupJs].concat(testPaths);
   var path = `${kibanaBins}${delimiter}${process.env.PATH}`;
-
-  if (command.include) {
-    var globs = command.include.split(',');
-    args = args.concat(globs);
-  }
 
   execFileSync(cmd, args, {
     cwd: plugin.root,


### PR DESCRIPTION
Adds a couple of new options/arguments to the `test:server` and `test:browser` commands.

### test:sever

Now uses a trailing `[files...]` pattern, so you can either leave it alone and get `server/**/__tests__/**/*.js` by default, or specify your own paths/globs, in which case the default is not used. Usage looks like this:

```
# default server test path used
plugin-helpers test:server 

# custom test globs and file paths specified
plugin-helpers test:server server/**/__tests__/**/*.js plugins/thing1/server/**/__tests__/**/*.js plugins/thing2/path/to/test.js
```

### test:browser

`--plugins <pluginIds>`: used to customize the value of `--kbnServer.testsBundle.pluginId` given to Kibana's browser test runner.