### PR TITLE
Separate the task runner and the command line parser

### DIFF
--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -39,13 +39,11 @@ program
   }));
 
 program
-  .command('test [files...]')
+  .command('test')
   .description('Run the server and browser tests')
   .on('--help', docs('test/all'))
   .action(taskRunner(function (command, files) {
-    run('testAll', {
-      files: files
-    });
+    run('testAll');
   }));
 
 program

--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -7,6 +7,14 @@ var run = require('../lib/run');
 var docs = require('../lib/docs');
 var enableCollectingUnknownOptions = require('../lib/enable_collecting_unknown_options');
 
+function taskRunner(fn) {
+  return function actionWrapper() {
+    var args = [].slice.apply(arguments);
+    var command = args.pop();
+    fn.apply(null, [command].concat(args));
+  };
+}
+
 program
   .version(pkg.version);
 
@@ -15,20 +23,28 @@ enableCollectingUnknownOptions(
     .command('start')
     .description('Start kibana and have it include this plugin')
     .on('--help', docs('start'))
-    .action(run('start'))
+    .action(taskRunner(function (command) {
+      run('start', {
+        flags: command.unkownOptions
+      });
+    }))
 );
 
 program
   .command('build')
   .description('Build a distributable archive')
   .on('--help', docs('build'))
-  .action(run('build'));
+  .action(taskRunner(function () {
+    run('build');
+  }));
 
 program
   .command('test')
   .description('Run the server and browser tests')
   .on('--help', docs('test/all'))
-  .action(run('testAll'));
+  .action(taskRunner(function (command, files) {
+    run('testAll');
+  }));
 
 program
   .command('test:browser')
@@ -36,13 +52,22 @@ program
   .option('--dev', 'Enable dev mode, keeps the test server running')
   .option('-p, --plugins <plugin-ids>', 'Manually specify which plugins\' test bundles to run')
   .on('--help', docs('test/browser'))
-  .action(run('testBrowser'));
+  .action(taskRunner(function (command) {
+    run('testBrowser', {
+      dev: Boolean(command.options.dev),
+      plugins: command.plugins,
+    });
+  }));
 
 program
   .command('test:server [files...]')
   .description('Run the server tests using mocha')
   .on('--help', docs('test/server'))
-  .action(run('testServer'));
+  .action(taskRunner(function (command, files) {
+    run('testServer', {
+      files: files
+    });
+  }));
 
 program
   .parse(process.argv);

--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -28,7 +28,7 @@ program
   .command('test')
   .description('Run the server and browser tests')
   .on('--help', docs('test/all'))
-  .action(run('test/all'));
+  .action(run('testAll'));
 
 program
   .command('test:browser')
@@ -36,13 +36,13 @@ program
   .option('--dev', 'Enable dev mode, keeps the test server running')
   .option('-p, --plugins <plugin-ids>', 'Manually specify which plugins\' test bundles to run')
   .on('--help', docs('test/browser'))
-  .action(run('test/browser'));
+  .action(run('testBrowser'));
 
 program
   .command('test:server [files...]')
   .description('Run the server tests using mocha')
   .on('--help', docs('test/server'))
-  .action(run('test/server'));
+  .action(run('testServer'));
 
 program
   .parse(process.argv);

--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -25,7 +25,7 @@ enableCollectingUnknownOptions(
     .on('--help', docs('start'))
     .action(taskRunner(function (command) {
       run('start', {
-        flags: command.unkownOptions
+        flags: command.unknownOptions
       });
     }))
 );

--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -39,11 +39,13 @@ program
   }));
 
 program
-  .command('test')
+  .command('test [files...]')
   .description('Run the server and browser tests')
   .on('--help', docs('test/all'))
   .action(taskRunner(function (command, files) {
-    run('testAll');
+    run('testAll', {
+      files: files
+    });
   }));
 
 program

--- a/lib/enable_collecting_unknown_options.js
+++ b/lib/enable_collecting_unknown_options.js
@@ -4,7 +4,7 @@ module.exports = function enableCollectingUnknownOptions(command) {
   command.allowUnknownOption();
   command.parseOptions = function (argv) {
     let opts = origParse.call(this, argv);
-    this.unkownOptions = opts.unknown;
+    this.unknownOptions = opts.unknown;
     return opts;
   };
 };

--- a/lib/plugin_config.js
+++ b/lib/plugin_config.js
@@ -23,6 +23,7 @@ module.exports = function (root) {
   return Object.assign({
     root: root,
     kibanaRoot: resolve(root, '../kibana'),
+    serverTestPaths: 'server/**/__tests__/**/*.js',
     id: pkg.name,
     pkg: pkg,
     version: pkg.version,

--- a/lib/plugin_config.js
+++ b/lib/plugin_config.js
@@ -23,7 +23,7 @@ module.exports = function (root) {
   return Object.assign({
     root: root,
     kibanaRoot: resolve(root, '../kibana'),
-    serverTestPaths: 'server/**/__tests__/**/*.js',
+    serverTestPatterns: ['server/**/__tests__/**/*.js'],
     id: pkg.name,
     pkg: pkg,
     version: pkg.version,

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,7 +1,10 @@
 var pluginConfig = require('./plugin_config');
+var tasks = require('./tasks');
 
 module.exports = function run(name) {
-  var action = require('../tasks/' + name);
+  var action = tasks[name];
+  if (!action) throw new Error('Invalid task: "' + name + '"');
+
   return function () {
     // call the action function with the plugin, then all
     // renaining arguments from commander

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,11 +1,10 @@
 var pluginConfig = require('./plugin_config');
 var tasks = require('./tasks');
 
-module.exports = function run(name) {
+module.exports = function run(name, options) {
   var action = tasks[name];
   if (!action) throw new Error('Invalid task: "' + name + '"');
 
   var plugin = pluginConfig();
-  var args = [].slice.apply(arguments).slice(1);
-  action.apply(null, [plugin, run].concat(args));
+  action(plugin, run, options);
 };

--- a/lib/run.js
+++ b/lib/run.js
@@ -5,12 +5,7 @@ module.exports = function run(name) {
   var action = tasks[name];
   if (!action) throw new Error('Invalid task: "' + name + '"');
 
-  return function () {
-    // call the action function with the plugin, then all
-    // renaining arguments from commander
-    var plugin = pluginConfig();
-    var args = [].slice.apply(arguments);
-
-    action.apply(null, [plugin, run].concat(args));
-  };
+  var plugin = pluginConfig();
+  var args = [].slice.apply(arguments).slice(1);
+  action.apply(null, [plugin, run].concat(args));
 };

--- a/lib/run.spec.js
+++ b/lib/run.spec.js
@@ -1,0 +1,30 @@
+/*eslint-env jest*/
+
+const testTask = jest.fn();
+const plugin = { id: 'testPlugin' };
+
+jest.mock('./plugin_config', () => () => plugin);
+jest.mock('./tasks', () => {
+  return { testTask };
+});
+const run = require('./run');
+
+describe('task runner', () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it('throw given an invalid task', function () {
+    const invalidTaskName = 'thisisnotavalidtasknameandneverwillbe';
+    const runner = () => run(invalidTaskName);
+
+    expect(runner).toThrow(/invalid task/i);
+  });
+
+  it('runs specified task with plugin and runner', function () {
+    run('testTask');
+
+    const args = testTask.mock.calls[0];
+    expect(testTask.mock.calls).toHaveLength(1);
+    expect(args[0]).toBe(plugin);
+    expect(args[1]).toBe(run);
+  });
+});

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -1,0 +1,13 @@
+var buildTask = require('../tasks/build');
+var startTask = require('../tasks/start');
+var testAllTask = require('../tasks/test/all');
+var testBrowserTask = require('../tasks/test/browser');
+var testServerTask = require('../tasks/test/server');
+
+module.exports = {
+  build: buildTask,
+  start: startTask,
+  testAll: testAllTask,
+  testBrowser: testBrowserTask,
+  testServer: testServerTask,
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@elastic/plugin-helpers",
   "version": "5.0.1-patch2",
   "description": "Just some helpers for kibana plugin devs.",
-  "main": "bin/plugin-helpers.js",
+  "main": "lib/run.js",
   "bin": {
     "plugin-helpers": "bin/plugin-helpers.js"
   },

--- a/tasks/build/build_action.spec.js
+++ b/tasks/build/build_action.spec.js
@@ -1,3 +1,4 @@
+/*eslint-env jest*/
 const resolve = require('path').resolve;
 const fs = require('fs');
 

--- a/tasks/start/start_action.js
+++ b/tasks/start/start_action.js
@@ -1,13 +1,13 @@
 var execFileSync = require('child_process').execFileSync;
 
-module.exports = function (plugin, run, command) {
-  command = command || {};
+module.exports = function (plugin, run, options) {
+  options = options || {};
 
   var cmd = (process.platform === 'win32') ? 'bin\\kibana.bat' : 'bin/kibana';
   var args = ['--dev', '--plugin-path', plugin.root];
 
-  if (command.unkownOptions) {
-    args = args.concat(command.unkownOptions);
+  if (options.flags) {
+    args = args.concat(options.flags);
   }
 
   execFileSync(cmd, args, {

--- a/tasks/test/all/test_all_action.js
+++ b/tasks/test/all/test_all_action.js
@@ -1,4 +1,6 @@
-module.exports = function testAllAction(plugin, run) {
-  run('testServer');
-  run('testBrowser');
+module.exports = function testAllAction(plugin, run, options) {
+  options = options || {};
+
+  run('testServer', options);
+  run('testBrowser', options);
 };

--- a/tasks/test/all/test_all_action.js
+++ b/tasks/test/all/test_all_action.js
@@ -1,4 +1,4 @@
 module.exports = function testAllAction(plugin, run) {
-  run('testServer')();
-  run('testBrowser')();
+  run('testServer');
+  run('testBrowser');
 };

--- a/tasks/test/all/test_all_action.js
+++ b/tasks/test/all/test_all_action.js
@@ -1,6 +1,4 @@
-module.exports = function testAllAction(plugin, run, options) {
-  options = options || {};
-
-  run('testServer', options);
-  run('testBrowser', options);
+module.exports = function testAllAction(plugin, run) {
+  run('testServer');
+  run('testBrowser');
 };

--- a/tasks/test/all/test_all_action.js
+++ b/tasks/test/all/test_all_action.js
@@ -1,4 +1,4 @@
 module.exports = function testAllAction(plugin, run) {
-  run('test/server')();
-  run('test/browser')();
+  run('testServer')();
+  run('testBrowser')();
 };

--- a/tasks/test/browser/test_browser_action.js
+++ b/tasks/test/browser/test_browser_action.js
@@ -1,20 +1,20 @@
 var execFileSync = require('child_process').execFileSync;
 
-module.exports = function testBrowserAction(plugin, run, command) {
-  command = command || {};
+module.exports = function testBrowserAction(plugin, run, options) {
+  options = options || {};
 
   var kbnServerArgs = [
     '--kbnServer.plugin-path=' + plugin.root
   ];
 
-  if (command.plugins) {
-    kbnServerArgs.push('--kbnServer.testsBundle.pluginId=' + command.plugins);
+  if (options.plugins) {
+    kbnServerArgs.push('--kbnServer.testsBundle.pluginId=' + options.plugins);
   } else {
     kbnServerArgs.push('--kbnServer.testsBundle.pluginId=' + plugin.id);
   }
 
   var cmd = 'npm';
-  var task = (command.dev) ? 'test:dev' : 'test:browser';
+  var task = (options.dev) ? 'test:dev' : 'test:browser';
   var args = ['run', task, '--'].concat(kbnServerArgs);
   execFileSync(cmd, args, {
     cwd: plugin.kibanaRoot,

--- a/tasks/test/server/test_server_action.js
+++ b/tasks/test/server/test_server_action.js
@@ -8,7 +8,7 @@ module.exports = function (plugin, run, options) {
   options = options || {};
 
   var cmd = 'mocha';
-  var testPaths = (options.files && options.files.length) ? options.files : 'server/**/__tests__/**/*.js';
+  var testPaths = (options.files && options.files.length) ? options.files : plugin.serverTestPaths;
   var args = ['--require', mochaSetupJs].concat(testPaths);
   var path = `${kibanaBins}${delimiter}${process.env.PATH}`;
 

--- a/tasks/test/server/test_server_action.js
+++ b/tasks/test/server/test_server_action.js
@@ -2,12 +2,13 @@ var resolve = require('path').resolve;
 var delimiter = require('path').delimiter;
 var execFileSync = require('child_process').execFileSync;
 
-module.exports = function (plugin, run, files) {
+module.exports = function (plugin, run, options) {
   var kibanaBins = resolve(plugin.kibanaRoot, 'node_modules/.bin');
   var mochaSetupJs = resolve(plugin.kibanaRoot, 'test/mocha_setup.js');
+  options = options || {};
 
   var cmd = 'mocha';
-  var testPaths = (files.length) ? files : 'server/**/__tests__/**/*.js';
+  var testPaths = (options.files && options.files.length) ? options.files : 'server/**/__tests__/**/*.js';
   var args = ['--require', mochaSetupJs].concat(testPaths);
   var path = `${kibanaBins}${delimiter}${process.env.PATH}`;
 

--- a/tasks/test/server/test_server_action.js
+++ b/tasks/test/server/test_server_action.js
@@ -8,7 +8,7 @@ module.exports = function (plugin, run, options) {
   options = options || {};
 
   var cmd = 'mocha';
-  var testPaths = (options.files && options.files.length) ? options.files : plugin.serverTestPaths;
+  var testPaths = (options.files && options.files.length) ? options.files : plugin.serverTestPatterns;
   var args = ['--require', mochaSetupJs].concat(testPaths);
   var path = `${kibanaBins}${delimiter}${process.env.PATH}`;
 


### PR DESCRIPTION
Blocked by #24
This PR starts at 62c0e60

This PR decouples the command parser from the task runner, and exposes the task runner when it's `require`d in node applications.

Doing so allows consumers to execute tasks without calling out the command line or going through a command line parser.