### PR TITLE
Allow custom build target via --build-destination flag

### DIFF
--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -34,7 +34,7 @@ program
   .command('build [files...]')
   .description('Build a distributable archive')
   .on('--help', docs('build'))
-  .option('--build-destination <path>', 'Custom target path for the build, relative to the plugin root')
+  .option('--build-destination <path>', 'Target path for the build output, absolute or relative to the plugin root')
   .option('-b, --build-version <version>', 'Version for the build output')
   .option('-k, --kibana-version <version>', 'Kibana version for the build output')
   .action(taskRunner(function (command, files) {

--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -34,10 +34,12 @@ program
   .command('build [files...]')
   .description('Build a distributable archive')
   .on('--help', docs('build'))
+  .option('--build-destination <path>', 'Custom target path for the build, relative to the plugin root')
   .option('-b, --build-version <version>', 'Version for the build output')
   .option('-k, --kibana-version <version>', 'Kibana version for the build output')
   .action(taskRunner(function (command, files) {
     run('build', {
+      buildDestination: command.buildDestination,
       buildVersion: command.buildVersion,
       kibanaVersion: command.kibanaVersion,
       files: files,

--- a/bin/plugin-helpers.js
+++ b/bin/plugin-helpers.js
@@ -34,7 +34,7 @@ program
   .command('build [files...]')
   .description('Build a distributable archive')
   .on('--help', docs('build'))
-  .option('--build-destination <path>', 'Target path for the build output, absolute or relative to the plugin root')
+  .option('-d, --build-destination <path>', 'Target path for the build output, absolute or relative to the plugin root')
   .option('-b, --build-version <version>', 'Version for the build output')
   .option('-k, --kibana-version <version>', 'Kibana version for the build output')
   .action(taskRunner(function (command, files) {

--- a/tasks/build/README.md
+++ b/tasks/build/README.md
@@ -7,3 +7,13 @@ be found at:
 ```
 build/{pkg.name}-{pkg.version}.zip
 ```
+
+If you use the `--build-destination` flag, the resulting build will be found
+in that directory.
+
+```
+plugin-helpers build --build-destination build/some/child/path
+
+# This will place the resulting build at:
+build/some/child/path/{pkg.name}-{pkg.version}.zip
+```

--- a/tasks/build/build_action.js
+++ b/tasks/build/build_action.js
@@ -1,4 +1,5 @@
 var join = require('path').join;
+var resolve = require('path').resolve;
 var inquirer = require('inquirer');
 
 var createBuild = require('./create_build');
@@ -16,7 +17,7 @@ module.exports = function (plugin, run, options) {
   }
 
   // allow options to override plugin info
-  if (options.buildDestination) buildTarget = options.buildDestination;
+  if (options.buildDestination) buildTarget = resolve(plugin.root, options.buildDestination);
   if (options.buildVersion) buildVersion = options.buildVersion;
   if (options.kibanaVersion) kibanaVersion = options.kibanaVersion;
 

--- a/tasks/build/build_action.js
+++ b/tasks/build/build_action.js
@@ -1,3 +1,4 @@
+var join = require('path').join;
 var inquirer = require('inquirer');
 
 var createBuild = require('./create_build');
@@ -7,6 +8,7 @@ module.exports = function (plugin, run, options) {
   var buildVersion = plugin.version;
   var kibanaVersion = (plugin.pkg.kibana && plugin.pkg.kibana.version) || plugin.pkg.version;
   var buildFiles = plugin.buildSourcePatterns;
+  var buildTarget = join(plugin.root, 'build');
 
   // allow source files to be overridden
   if (options.files && options.files.length) {
@@ -14,15 +16,16 @@ module.exports = function (plugin, run, options) {
   }
 
   // allow options to override plugin info
+  if (options.buildDestination) buildTarget = options.buildDestination;
   if (options.buildVersion) buildVersion = options.buildVersion;
   if (options.kibanaVersion) kibanaVersion = options.kibanaVersion;
 
   if (kibanaVersion === 'kibana') {
     return askForKibanaVersion().then(function (customKibanaVersion) {
-      return createBuild(plugin, buildVersion, customKibanaVersion, buildFiles);
+      return createBuild(plugin, buildTarget, buildVersion, customKibanaVersion, buildFiles);
     });
   } else {
-    return createBuild(plugin, buildVersion, kibanaVersion, buildFiles);
+    return createBuild(plugin, buildTarget, buildVersion, kibanaVersion, buildFiles);
   }
 };
 

--- a/tasks/build/build_action.spec.js
+++ b/tasks/build/build_action.spec.js
@@ -44,7 +44,7 @@ describe('build_action', () => {
 
       return buildAction(PLUGIN, noop, options).then(() => {
         expect(mockBuild.mock.calls).toHaveLength(1);
-        const [ plugin, buildVersion, kibanaVersion, files ] = mockBuild.mock.calls[0];
+        const [ plugin, buildTarget, buildVersion, kibanaVersion, files ] = mockBuild.mock.calls[0];
         expect(buildVersion).toBe('1.2.3');
         expect(kibanaVersion).toBe('4.5.6');
       });
@@ -53,7 +53,7 @@ describe('build_action', () => {
     it('uses default file list without files option', function () {
       return buildAction(PLUGIN).then(() => {
         expect(mockBuild.mock.calls).toHaveLength(1);
-        const [ plugin, buildVersion, kibanaVersion, files ] = mockBuild.mock.calls[0];
+        const [ plugin, buildTarget, buildVersion, kibanaVersion, files ] = mockBuild.mock.calls[0];
         PLUGIN.buildSourcePatterns.forEach(file => expect(files).toContain(file));
       });
     });
@@ -70,7 +70,7 @@ describe('build_action', () => {
 
       return buildAction(PLUGIN, noop, options).then(() => {
         expect(mockBuild.mock.calls).toHaveLength(1);
-        const [ plugin, buildVersion, kibanaVersion, files ] = mockBuild.mock.calls[0];
+        const [ plugin, buildTarget, buildVersion, kibanaVersion, files ] = mockBuild.mock.calls[0];
         options.files.forEach(file => expect(files).toContain(file));
       });
     });

--- a/tasks/build/create_build.js
+++ b/tasks/build/create_build.js
@@ -5,10 +5,9 @@ var zip = require('gulp-zip');
 var map = require('through2-map').obj;
 var rename = require('gulp-rename');
 
-module.exports = function createBuild(plugin, buildVersion, kibanaVersion, files) {
+module.exports = function createBuild(plugin, buildTarget, buildVersion, kibanaVersion, files) {
   var buildId = `${plugin.id}-${buildVersion}`;
   var buildSource = plugin.root;
-  var buildTarget = join(plugin.root, 'build');
 
   return new Promise(function (resolve) {
     vfs


### PR DESCRIPTION
Adds `--build-destination` flag, which is used as the `buildTarget` when the build is created.

### Usage

`plugin-helpers build`

This will create the build in the default `build` directory, inside the required `kibana/<plugin.id>` path. The final result will be a zip file at `build/<plugin.id>-<plugin.version>.zip`.

`plugin-helpers build --build-destination custom/path`

This will create the build in `custom/path`, inside the required `kibana/<plugin.id>` path. The final result will be a zip file at `custom/path/<plugin.id>-<plugin.version>.zip`.