### PR TITLE
Update URLs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/spalger/kibana-plugin-helpers.git"
+    "url": "git+https://github.com/elastic/kibana-plugin-helpers.git"
   },
   "bugs": {
-    "url": "https://github.com/spalger/kibana-plugin-helpers/issues"
+    "url": "https://github.com/elastic/kibana-plugin-helpers/issues"
   },
-  "homepage": "https://github.com/spalger/kibana-plugin-helpers#readme"
+  "homepage": "https://github.com/elastic/kibana-plugin-helpers#readme"
 }


### PR DESCRIPTION
The package.json URLs are still referencing @spalger's version, whilst development and collaboration happens on @elastic's version. This means the links on npm's page for this module point to the wrong repo - see the right hand bar https://www.npmjs.com/package/@elastic/plugin-helpers