### PR TITLE
Allow helpers to run on pre-6.0 node

### DIFF
--- a/lib/enable_collecting_unknown_options.js
+++ b/lib/enable_collecting_unknown_options.js
@@ -3,7 +3,7 @@ module.exports = function enableCollectingUnknownOptions(command) {
   var origParse = command.parseOptions;
   command.allowUnknownOption();
   command.parseOptions = function (argv) {
-    let opts = origParse.call(this, argv);
+    var opts = origParse.call(this, argv);
     this.unknownOptions = opts.unknown;
     return opts;
   };


### PR DESCRIPTION
Closes #33

Changes `let` to `var` in `lib/enable_collecting_unknown_options.js`