### PR TITLE
Fix running tasks on Windows

### DIFF
--- a/lib/win_cmd.js
+++ b/lib/win_cmd.js
@@ -1,6 +1,5 @@
-var os = require('os');
-var platform = os.platform();
+var platform = require('os').platform();
 
 module.exports = function winCmd(cmd) {
   return /^win/.test(platform) ? cmd + '.cmd' : cmd;
-}
+};

--- a/lib/win_cmd.js
+++ b/lib/win_cmd.js
@@ -1,0 +1,6 @@
+var os = require('os');
+var platform = os.platform();
+
+module.exports = function winCmd(cmd) {
+  return /^win/.test(platform) ? cmd + '.cmd' : cmd;
+}

--- a/tasks/build/create_build.js
+++ b/tasks/build/create_build.js
@@ -8,6 +8,7 @@ var rename = require('gulp-rename');
 
 var rewritePackageJson = require('./rewrite_package_json');
 var gitInfo = require('./git_info');
+var winCmd = require('../../lib/win_cmd');
 
 module.exports = function createBuild(plugin, buildTarget, buildVersion, kibanaVersion, files) {
   var buildSource = plugin.root;
@@ -34,6 +35,7 @@ module.exports = function createBuild(plugin, buildTarget, buildVersion, kibanaV
     })
     .then(function () {
       // install packages in build
+      var cmd = winCmd('npm');
       var options = {
         cwd: buildRoot,
         stdio: ['ignore', 'ignore', 'pipe'],
@@ -41,11 +43,12 @@ module.exports = function createBuild(plugin, buildTarget, buildVersion, kibanaV
 
       try {
         // use yarn if yarn lockfile is found in the build
+        cmd = winCmd('yarn');
         statSync(join(buildRoot, 'yarn.lock'));
-        execFileSync('yarn', ['install', '--production'], options);
+        execFileSync(cmd, ['install', '--production'], options);
       } catch (e) {
         // use npm if there is no yarn lockfile in the build
-        execFileSync('npm', ['install', '--production', '--no-bin-links'], options);
+        execFileSync(cmd, ['install', '--production', '--no-bin-links'], options);
       }
     });
 };

--- a/tasks/test/browser/test_browser_action.js
+++ b/tasks/test/browser/test_browser_action.js
@@ -1,4 +1,5 @@
 var execFileSync = require('child_process').execFileSync;
+var winCmd = require('../../../lib/win_cmd');
 
 module.exports = function testBrowserAction(plugin, run, options) {
   options = options || {};
@@ -13,7 +14,7 @@ module.exports = function testBrowserAction(plugin, run, options) {
     kbnServerArgs.push('--kbnServer.tests_bundle.pluginId=' + plugin.id);
   }
 
-  var cmd = 'npm';
+  var cmd = winCmd('npm');
   var task = (options.dev) ? 'test:dev' : 'test:browser';
   var args = ['run', task, '--'].concat(kbnServerArgs);
   execFileSync(cmd, args, {

--- a/tasks/test/server/test_server_action.js
+++ b/tasks/test/server/test_server_action.js
@@ -1,6 +1,7 @@
 var resolve = require('path').resolve;
 var delimiter = require('path').delimiter;
 var execFileSync = require('child_process').execFileSync;
+var winCmd = require('../../../lib/win_cmd');
 
 module.exports = function (plugin, run, options) {
   options = options || {};
@@ -13,7 +14,8 @@ module.exports = function (plugin, run, options) {
     testPaths = options.files;
   }
 
-  var cmd = resolve(plugin.kibanaRoot, 'node_modules', '.bin', 'mocha');
+  var fullCmd = resolve(plugin.kibanaRoot, 'node_modules', '.bin', 'mocha');
+  var cmd = winCmd(fullCmd);
   var args = ['--require', mochaSetupJs].concat(testPaths);
   var path = `${kibanaBins}${delimiter}${process.env.PATH}`;
 

--- a/tasks/test/server/test_server_action.js
+++ b/tasks/test/server/test_server_action.js
@@ -13,7 +13,7 @@ module.exports = function (plugin, run, options) {
     testPaths = options.files;
   }
 
-  var cmd = 'mocha';
+  var cmd = resolve(plugin.kibanaRoot, 'node_modules', '.bin', 'mocha');
   var args = ['--require', mochaSetupJs].concat(testPaths);
   var path = `${kibanaBins}${delimiter}${process.env.PATH}`;
 


### PR DESCRIPTION
Windows commands use a `.cmd` suffix on their executables. This adds a wrapper to provide that for tasks that require a child process:

- browser tests
- server tests
- yarn/npm in the build

Closes #36 