### PR TITLE
Added helpers, KIBANA_ROOT environment override

### DIFF
--- a/lib/config_file.js
+++ b/lib/config_file.js
@@ -3,6 +3,7 @@ var readFileSync = require('fs').readFileSync;
 
 var configFiles = [ '.kibana-plugin-helpers.json', '.kibana-plugin-helpers.dev.json' ];
 var configCache = {};
+var KIBANA_ROOT_OVERRIDE = process.env.KIBANA_ROOT ? resolve(process.env.KIBANA_ROOT) : null;
 
 module.exports = function (root) {
   if (!root) root = process.cwd();
@@ -25,6 +26,7 @@ module.exports = function (root) {
 
   // if the kibanaRoot is set, use resolve to ensure correct resolution
   if (config.kibanaRoot) config.kibanaRoot = resolve(root, config.kibanaRoot);
+  if (KIBANA_ROOT_OVERRIDE) config.kibanaRoot = KIBANA_ROOT_OVERRIDE;
 
   return config;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,13 @@
+var run = require('./run');
+var utils = require('./utils');
+
+module.exports = function () {
+  console.error(
+    'running tasks with the default export of @elastic/plugin-helpers is deprecated.' +
+    'use `require(\'@elastic/plugin-helpers\').run()` instead'
+  );
+
+  return run.apply(this, arguments);
+};
+
+Object.assign(module.exports, { run: run }, utils);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,28 @@
+var resolve = require('path').resolve;
+
+var pluginConfig = require('./config_file');
+
+function babelRegister() {
+  var plugin = pluginConfig();
+  require(resolve(plugin.kibanaRoot, 'src/optimize/babel/register'));
+}
+
+function resolveKibanaPath(path) {
+  var plugin = pluginConfig();
+  return resolve(plugin.kibanaRoot, path);
+}
+
+function createToolingLog(level) {
+  return require(resolveKibanaPath('src/utils')).createToolingLog(level);
+}
+
+function readFtrConfigFile(log, path, settingOverrides) {
+  return require(resolveKibanaPath('src/functional_test_runner')).readConfigFile(log, path, settingOverrides);
+}
+
+module.exports = {
+  babelRegister: babelRegister,
+  resolveKibanaPath: resolveKibanaPath,
+  createToolingLog: createToolingLog,
+  readFtrConfigFile: readFtrConfigFile,
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@elastic/plugin-helpers",
   "version": "6.0.4",
   "description": "Just some helpers for kibana plugin devs.",
-  "main": "lib/run.js",
+  "main": "lib/index.js",
   "bin": {
     "plugin-helpers": "bin/plugin-helpers.js"
   },


### PR DESCRIPTION
 - **Deprecation:** Rather than exporting the run function as the default export, it is now one of many helpers (though it still works but logs a deprecation warning).
- The `KIBANA_ROOT` environment variable is now used to override the `kibanaRoot` setting in `.kibana-plugin-helpers.json` and `.kibana-plugin-helpers.dev.json`
- This module previously focused on sharing specific build operations with plugins, but there is more to the build tooling in Kibana than tasks. The components we use to build the build tasks are often reusable, and often useful outside of just running the task, especially as we move toward https://github.com/elastic/kibana/issues/11095. To help plugins use these reusable components this module now exports little functions that will share create/call them in the Kibana repo from the plugin, using the `kibanaRoot` config. These helpers are:
   - **`require('@elastic/plugin-helpers').babelRegister()`**
     Hook into Kibana's babel register config.
   - **`require('@elastic/plugin-helpers').resolveKibanaPath(path)`**
     Resolve a path relative to the Kibana repository, taking into account the `kibanaRoot` config 
   - **`require('@elastic/plugin-helpers').createToolingLog(level)`**
     Create an instance of the Kibana ToolingLog, see https://github.com/elastic/kibana/blob/master/src/utils/tooling_log/tooling_log.js
   - **`require('@elastic/plugin-helpers').readFtrConfigFile(log, path, settingOverrides)`**
     Read a functional test runner config file at a path