### PR TITLE
Feat/add translations and a script for running test without linting that isn't the jest script

### DIFF
--- a/lib/plugin_config.js
+++ b/lib/plugin_config.js
@@ -11,7 +11,7 @@ module.exports = function (root) {
   const buildSourcePatterns = [
     'package.json',
     'index.js',
-    '{lib,public,server,webpackShims}/**/*',
+    '{lib,public,server,webpackShims,translations}/**/*',
   ];
 
   // add shrinkwrap and lock files, if they exist

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "npm run lint && npm run jest",
+    "test:only": "npm run jest",
     "jest": "jest",
     "lint": "eslint bin/ help/ tasks/"
   },

--- a/tasks/build/__fixtures__/test_plugin/translations/es.json
+++ b/tasks/build/__fixtures__/test_plugin/translations/es.json
@@ -1,0 +1,4 @@
+{
+  "UI-WELCOME_MESSAGE": "Cargando Kibana",
+  "UI-WELCOME_ERROR": "Kibana no se cargó correctamente. Heck la salida del servidor para obtener más información."
+}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana-plugin-helpers/issues/47

Adds `translations` to the list of paths in the `buildSourcePatterns` setting.

@spalger it's been a little while since I've been in this code, so I wanted you to confirm that this is the only change I need to make here.