### PR TITLE
Feat: add includePlugins setting

### DIFF
--- a/lib/config_file.js
+++ b/lib/config_file.js
@@ -24,8 +24,12 @@ module.exports = function (root) {
     }
   });
 
-  // if the kibanaRoot is set, use resolve to ensure correct resolution
-  if (config.kibanaRoot) config.kibanaRoot = resolve(root, config.kibanaRoot);
+  // use resolve to ensure correct resolution of paths
+  const { kibanaRoot, includePlugins } = config;
+  if (kibanaRoot) config.kibanaRoot = resolve(root, kibanaRoot);
+  if (includePlugins) config.includePlugins = includePlugins.map(path => resolve(root, path));
+
+  // allow env setting to override kibana root from config
   if (KIBANA_ROOT_OVERRIDE) config.kibanaRoot = KIBANA_ROOT_OVERRIDE;
 
   return config;

--- a/tasks/start/start_action.js
+++ b/tasks/start/start_action.js
@@ -1,3 +1,4 @@
+const { resolve } = require('path');
 const execFileSync = require('child_process').execFileSync;
 
 module.exports = function (plugin, run, options) {
@@ -5,6 +6,12 @@ module.exports = function (plugin, run, options) {
 
   const cmd = (process.platform === 'win32') ? 'bin\\kibana.bat' : 'bin/kibana';
   let args = ['--dev', '--plugin-path', plugin.root];
+
+  if (Array.isArray(plugin.includePlugins)) {
+    plugin.includePlugins.forEach((path) => {
+      args = args.concat(['--plugin-path', resolve(path)]);
+    });
+  }
 
   if (options.flags) {
     args = args.concat(options.flags);

--- a/tasks/start/start_action.js
+++ b/tasks/start/start_action.js
@@ -1,4 +1,3 @@
-const { resolve } = require('path');
 const execFileSync = require('child_process').execFileSync;
 
 module.exports = function (plugin, run, options) {
@@ -9,7 +8,7 @@ module.exports = function (plugin, run, options) {
 
   if (Array.isArray(plugin.includePlugins)) {
     plugin.includePlugins.forEach((path) => {
-      args = args.concat(['--plugin-path', resolve(path)]);
+      args = args.concat(['--plugin-path', path]);
     });
   }
 


### PR DESCRIPTION
For this change to work, Kibana will need this PR merged: https://github.com/elastic/kibana/pull/14181

It can be handy to include other plugins when you are starting up your own. For example, when you have a dependency on another plugin, and maybe need to develop on both of them at the same time.

This PR adds support for an `includePlugins` setting which will be used to append additional `--plugin-paths` to the plugin you're already using this helper on.

Usage (in the config file):

```json
{
  "includePlugins": [
    "../relative/path/to/plugin",
    "/or/absolute/path/to/plugin"
  ]
}
```

As with pretty much all the settings, this is most useful mixed with the `.kibana-plugin-helpers.json` and dev version of the config files.