### PR TITLE
Fix: readme include docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # kibana-plugin-helpers
 
+[![Apache License](https://img.shields.io/badge/license-apache_2.0-a9215a.svg)](https://raw.githubusercontent.com/elastic/kibana-plugin-helpers/master/LICENSE)
 [![CircleCI](https://circleci.com/gh/elastic/kibana-plugin-helpers/tree/master.svg?style=svg)](https://circleci.com/gh/elastic/kibana-plugin-helpers/tree/master)
 
 Just some helpers for kibana plugin devs.
@@ -57,7 +58,3 @@ Setting | Description
 `buildDestination` | Target path for the build output, absolute or relative to the plugin root
 `buildVersion` | Version for the build output
 `kibanaVersion` | Kibana version for the build output (added to package.json)
-
-# License
-
-Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # kibana-plugin-helpers
 
 [![Apache License](https://img.shields.io/badge/license-apache_2.0-a9215a.svg)](https://raw.githubusercontent.com/elastic/kibana-plugin-helpers/master/LICENSE)
-[![CircleCI](https://circleci.com/gh/elastic/kibana-plugin-helpers/tree/master.svg?style=svg)](https://circleci.com/gh/elastic/kibana-plugin-helpers/tree/master)
+[![CircleCI](https://img.shields.io/circleci/project/github/elastic/kibana-plugin-helpers.svg)](https://circleci.com/gh/elastic/kibana-plugin-helpers/tree/master)
 
 Just some helpers for kibana plugin devs.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,30 @@ Plugin Helpers | Kibana
 6.x | 4.6+
 5.x | 4.x
 
+## Configuration
+
+`plugin-helpers` accepts a number of settings, which can be specified at runtime, or included in a `.kibana-plugin-helpers.json` file if you'd like to bundle those settings with your project. 
+
+It will also observe a `.kibana-plugin-helpers.dev.json`, much like Kibana does, which we encourage you to add to your `.gitignore` file and use for local settings that you don't intend to share. These "dev" settings will override any settings in the normal json config.
+
+All configuration setting listed below can simply can be included in the json config files. If you intend to inline the command, you will need to convert the setting to snake case (ie. `skipArchive` becomes `--skip-archive`).
+
+### `start`
+
+Setting | Description
+------- | -----------
+`includePlugins` | Intended to be used in a config file, an array of additional plugin paths to include, absolute or relative to the plugin root
+`*` | Any options/flags included will be passed unmodified to the Kibana binary
+
+### `build`
+
+Setting | Description
+------- | -----------
+`skipArchive` | Don't create the zip file, leave the build path alone
+`buildDestination` | Target path for the build output, absolute or relative to the plugin root
+`buildVersion` | Version for the build output
+`kibanaVersion` | Kibana version for the build output (added to package.json)
+
 # License
 
 Apache-2.0

--- a/README.md
+++ b/README.md
@@ -6,13 +6,10 @@ Just some helpers for kibana plugin devs.
 
 This simple CLI has several tasks that plugin devs can run from to easily debug, test, or package kibana plugins.
 
-See the [docs](docs) directory for more info.
-
 ```sh
 $ plugin-helpers help
 
   Usage: plugin-helpers [options] [command]
-
 
   Commands:
 
@@ -28,6 +25,14 @@ $ plugin-helpers help
     -V, --version  output the version number
 
 ```
+
+## Versions
+
+Plugin Helpers | Kibana
+-------------- | ------
+7.x | 4.6+ (node 6+ only)
+6.x | 4.6+
+5.x | 4.x
 
 # License
 


### PR DESCRIPTION
Document the settings available for `start` and `build`, and remove the broken link to the docs that were removed some time ago.

First steps toward https://github.com/elastic/kibana-plugin-helpers/issues/29