### PR TITLE
Use scripts/kibana instead of bin if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ $ plugin-helpers help
 
 Plugin Helpers | Kibana
 -------------- | ------
-7.x | 4.6+ (node 6+ only)
-6.x | 4.6+
+8.x | 7.0+
+7.x | 4.6.x to 6.x (node 6+ only)
+6.x | 4.6.x to 6.x
 5.x | 4.x
 
 ## Configuration

--- a/tasks/start/start_action.js
+++ b/tasks/start/start_action.js
@@ -1,21 +1,12 @@
 const execFileSync = require('child_process').execFileSync;
-const { existsSync } = require('fs');
-const { resolve, join } = require('path');
+const  { join } = require('path');
 
 module.exports = function (plugin, run, options) {
   options = options || {};
-  let args = [];
-  let cmd;
-  const relativeScript = join('scripts', 'kibana.js');
-  const absoluteScript = resolve(plugin.kibanaRoot, relativeScript);
-  if (existsSync(absoluteScript)) {
-    cmd = 'node';
-    args.push(relativeScript);
-  } else {
-    cmd = (process.platform === 'win32') ? 'bin\\kibana.bat' : 'bin/kibana';
-  }
 
-  args = args.concat(['--dev', '--plugin-path', plugin.root]);
+  const cmd = 'node';
+  const script = join('scripts', 'kibana.js');
+  let args = [script, '--dev', '--plugin-path', plugin.root];
 
   if (Array.isArray(plugin.includePlugins)) {
     plugin.includePlugins.forEach((path) => {

--- a/tasks/start/start_action.js
+++ b/tasks/start/start_action.js
@@ -1,16 +1,16 @@
 const execFileSync = require('child_process').execFileSync;
-const { existsSync } = require('fs')
-const { resolve, join } = require('path')
+const { existsSync } = require('fs');
+const { resolve, join } = require('path');
 
 module.exports = function (plugin, run, options) {
   options = options || {};
   let args = [];
   let cmd;
-  const relativeScript = join('scripts', 'kibana.js')
+  const relativeScript = join('scripts', 'kibana.js');
   const absoluteScript = resolve(plugin.kibanaRoot, relativeScript);
   if (existsSync(absoluteScript)) {
-    cmd = 'node'
-    args.push(relativeScript)
+    cmd = 'node';
+    args.push(relativeScript);
   } else {
     cmd = (process.platform === 'win32') ? 'bin\\kibana.bat' : 'bin/kibana';
   }

--- a/tasks/start/start_action.js
+++ b/tasks/start/start_action.js
@@ -1,10 +1,21 @@
 const execFileSync = require('child_process').execFileSync;
+const { existsSync } = require('fs')
+const { resolve, join } = require('path')
 
 module.exports = function (plugin, run, options) {
   options = options || {};
+  let args = [];
+  let cmd;
+  const relativeScript = join('scripts', 'kibana.js')
+  const absoluteScript = resolve(plugin.kibanaRoot, relativeScript);
+  if (existsSync(absoluteScript)) {
+    cmd = 'node'
+    args.push(relativeScript)
+  } else {
+    cmd = (process.platform === 'win32') ? 'bin\\kibana.bat' : 'bin/kibana';
+  }
 
-  const cmd = (process.platform === 'win32') ? 'bin\\kibana.bat' : 'bin/kibana';
-  let args = ['--dev', '--plugin-path', plugin.root];
+  args = args.concat(['--dev', '--plugin-path', plugin.root]);
 
   if (Array.isArray(plugin.includePlugins)) {
     plugin.includePlugins.forEach((path) => {


### PR DESCRIPTION
With https://github.com/elastic/kibana/pull/13806 kibana will no longer fallback to the global node installation, and for development `node scripts/kibana` is expected to be used instead.

This adds a check to use the scripts/kibana file if it exists, and then falls back to using bin/kibana.