### PR TITLE
[createToolingLog] update require path for toolingLog

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,7 +23,7 @@ function resolveKibanaPath(path) {
 }
 
 function createToolingLog(level) {
-  return require(resolveKibanaPath('src/utils')).createToolingLog(level);
+  return require(resolveKibanaPath('src/dev')).createToolingLog(level);
 }
 
 function readFtrConfigFile(log, path, settingOverrides) {


### PR DESCRIPTION
elastic/kibana#14890 moved the location of the tooling log, and this points the plugin helpers to the right place.