### PR TITLE
[createToolingLog] update require path for toolingLog (7.x)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,7 +23,10 @@ function resolveKibanaPath(path) {
 }
 
 function createToolingLog(level) {
-  return require(resolveKibanaPath('src/utils')).createToolingLog(level);
+  // The tooling log location changed in 6.1.0, see https://github.com/elastic/kibana/pull/14890
+  const utils = require(resolveKibanaPath('src/utils'));
+  if (utils.createToolingLog) return utils.createToolingLog(level);
+  return require(resolveKibanaPath('src/dev')).createToolingLog(level);
 }
 
 function readFtrConfigFile(log, path, settingOverrides) {


### PR DESCRIPTION
Backport of https://github.com/elastic/kibana-plugin-helpers/pull/54

Will use old `src/utils` path if the method exists, and the new `src/dev` path if not.