### PR TITLE
[config] throw if config file has a syntax error

### DIFF
--- a/lib/config_file.js
+++ b/lib/config_file.js
@@ -19,13 +19,16 @@ module.exports = function (root) {
       const content = JSON.parse(readFileSync(resolve(root, configFile)));
       config = Object.assign(config, content);
     } catch (e) {
-      // noop
+      // rethrow error unless it's complaining about file not existing
+      if (e.code !== 'ENOENT') {
+        throw e;
+      }
     }
   });
 
   const deprecationMsg = 'has been removed from `@elastic/plugin-helpers`. ' +
     'During development your plugin must be located in `../kibana-extra/{pluginName}` ' +
-    'relative to the Kibana directory to work with this package.\n'
+    'relative to the Kibana directory to work with this package.\n';
 
   if (config.kibanaRoot) {
     throw new Error(


### PR DESCRIPTION
Fixes #64 

When the config file is found but parsing throws an error, or anything in that try/catch throws an error, rethrow the error. Only ignore `ENOENT` errors.