### PR TITLE
[plugin-helpers] report task failures to CLI with exitCode 1

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 ---
 extends: "@elastic/kibana"
 
+plugins:
+  - jest
+
 rules:
   prefer-object-spread/prefer-object-spread: 0

--- a/cli.js
+++ b/cli.js
@@ -1,17 +1,9 @@
 const program = require('commander');
 
 const pkg = require('./package.json');
-const run = require('./lib/run');
+const createCommanderAction = require('./lib/commander_action');
 const docs = require('./lib/docs');
 const enableCollectingUnknownOptions = require('./lib/enable_collecting_unknown_options');
-
-function taskRunner(fn) {
-  return function actionWrapper() {
-    const args = [].slice.apply(arguments);
-    const command = args.pop();
-    fn.apply(null, [command].concat(args));
-  };
-}
 
 program
   .version(pkg.version);
@@ -21,11 +13,9 @@ enableCollectingUnknownOptions(
     .command('start')
     .description('Start kibana and have it include this plugin')
     .on('--help', docs('start'))
-    .action(taskRunner(function (command) {
-      run('start', {
-        flags: command.unknownOptions
-      });
-    }))
+    .action(createCommanderAction('start', (command) => ({
+      flags: command.unknownOptions
+    })))
 );
 
 program
@@ -36,23 +26,19 @@ program
   .option('-d, --build-destination <path>', 'Target path for the build output, absolute or relative to the plugin root')
   .option('-b, --build-version <version>', 'Version for the build output')
   .option('-k, --kibana-version <version>', 'Kibana version for the build output')
-  .action(taskRunner(function (command, files) {
-    run('build', {
-      buildDestination: command.buildDestination,
-      buildVersion: command.buildVersion,
-      kibanaVersion: command.kibanaVersion,
-      skipArchive: Boolean(command.skipArchive),
-      files: files,
-    });
-  }));
+  .action(createCommanderAction('build', (command, files) => ({
+    buildDestination: command.buildDestination,
+    buildVersion: command.buildVersion,
+    kibanaVersion: command.kibanaVersion,
+    skipArchive: Boolean(command.skipArchive),
+    files: files,
+  })));
 
 program
   .command('test')
   .description('Run the server and browser tests')
   .on('--help', docs('test/all'))
-  .action(taskRunner(function (command) {
-    run('testAll');
-  }));
+  .action(createCommanderAction('testAll'));
 
 program
   .command('test:browser')
@@ -60,22 +46,18 @@ program
   .option('--dev', 'Enable dev mode, keeps the test server running')
   .option('-p, --plugins <plugin-ids>', 'Manually specify which plugins\' test bundles to run')
   .on('--help', docs('test/browser'))
-  .action(taskRunner(function (command) {
-    run('testBrowser', {
-      dev: Boolean(command.dev),
-      plugins: command.plugins,
-    });
-  }));
+  .action(createCommanderAction('testBrowser', (command) => ({
+    dev: Boolean(command.dev),
+    plugins: command.plugins,
+  })));
 
 program
   .command('test:server [files...]')
   .description('Run the server tests using mocha')
   .on('--help', docs('test/server'))
-  .action(taskRunner(function (command, files) {
-    run('testServer', {
-      files: files
-    });
-  }));
+  .action(createCommanderAction('testServer', (command, files) => ({
+    files: files
+  })));
 
 program
   .parse(process.argv);

--- a/lib/__snapshots__/commander_action.spec.js.snap
+++ b/lib/__snapshots__/commander_action.spec.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`commander action exits with status 1 when task throws error asynchronously 1`] = `
+Array [
+  Array [
+    "Task \\"mockTask\\" failed:
+
+Error: async error thrown
+  ...stack trace...
+",
+  ],
+]
+`;
+
+exports[`commander action exits with status 1 when task throws synchronously 1`] = `
+Array [
+  Array [
+    "Task \\"mockTask\\" failed:
+
+Error: sync error thrown
+  ...stack trace...
+",
+  ],
+]
+`;
+
+exports[`commander action passes args to getOptions, calls run() with taskName and options 1`] = `
+Array [
+  Array [
+    "taskName",
+    Object {
+      "args": Array [
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+      ],
+    },
+  ],
+]
+`;

--- a/lib/commander_action.js
+++ b/lib/commander_action.js
@@ -1,0 +1,13 @@
+const run = require('./run');
+
+module.exports = function createCommanderAction(taskName, getOptions = () => {}) {
+  return (command, ...args) => {
+    return Promise
+      .resolve()
+      .then(() => run(taskName, getOptions(...args)))
+      .catch((error) => {
+        process.stderr.write(`Task "${taskName}" failed:\n\n${error.stack || error.message}\n`);
+        process.exit(1);
+      });
+  };
+};

--- a/lib/commander_action.spec.js
+++ b/lib/commander_action.spec.js
@@ -1,0 +1,71 @@
+/*eslint-env jest*/
+
+const createCommanderAction = require('./commander_action');
+const run = require('./run');
+
+jest.mock('./run', () => jest.fn());
+
+const STACK_TRACE_RE = /\n(?:\s+at .+(?:\n|$))+/g;
+expect.addSnapshotSerializer({
+  print(val, serialize) {
+    return serialize(val.replace(STACK_TRACE_RE, '\n  ...stack trace...\n'));
+  },
+
+  test(val) {
+    return typeof val === 'string' && STACK_TRACE_RE.test(val);
+  },
+});
+
+beforeAll(() => {
+  jest.spyOn(process.stderr, 'write').mockImplementation(() => {});
+  jest.spyOn(process, 'exit').mockImplementation(() => {});
+});
+
+beforeEach(() => {
+  run.mockReset();
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe('commander action', () => {
+  it('creates a function', () => {
+    expect(typeof createCommanderAction()).toBe('function');
+  });
+
+  it('passes args to getOptions, calls run() with taskName and options', () => {
+    const action = createCommanderAction('taskName', (...args) => ({ args }));
+    return action('a', 'b', 'c', 'd', 'e', 'f').then(() => {
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(run.mock.calls).toMatchSnapshot();
+    });
+  });
+
+  it('exits with status 1 when task throws synchronously', () => {
+    run.mockImplementation(() => {
+      throw new Error('sync error thrown');
+    });
+
+    return createCommanderAction('mockTask')().then(() => {
+      expect(process.stderr.write).toHaveBeenCalledTimes(1);
+      expect(process.stderr.write.mock.calls).toMatchSnapshot();
+      expect(process.exit).toHaveBeenCalledTimes(1);
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it('exits with status 1 when task throws error asynchronously', () => {
+    run.mockImplementation(() => {
+      return Promise.reject(new Error('async error thrown'));
+    });
+
+    return createCommanderAction('mockTask')().then(() => {
+      expect(process.stderr.write).toHaveBeenCalledTimes(1);
+      expect(process.stderr.write.mock.calls).toMatchSnapshot();
+      expect(process.exit).toHaveBeenCalledTimes(1);
+      expect(process.exit).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,7 +3,9 @@ const tasks = require('./tasks');
 
 module.exports = function run(name, options) {
   const action = tasks[name];
-  if (!action) throw new Error('Invalid task: "' + name + '"');
+  if (!action) {
+    throw new Error('Invalid task: "' + name + '"');
+  }
 
   const plugin = pluginConfig();
   return action(plugin, run, options);

--- a/package.json
+++ b/package.json
@@ -33,17 +33,22 @@
     "eslint": "^4.1.0",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-import": "^2.6.0",
-    "eslint-plugin-jest": "^21.0.0",
+    "eslint-plugin-jest": "^21.15.0",
     "eslint-plugin-mocha": "^4.9.0",
     "eslint-plugin-prefer-object-spread": "^1.2.1",
     "eslint-plugin-react": "^7.1.0",
-    "jest": "^17.0.3"
+    "jest": "^22.4.3"
   },
   "engines": {
     "node": "^6.11.5 || ^8.8.0"
   },
   "directories": {
     "doc": "docs"
+  },
+  "jest": {
+    "modulePathIgnorePatterns": [
+      "__fixtures__"
+    ]
   },
   "repository": {
     "type": "git",

--- a/tasks/build/__snapshots__/build_action.spec.js.snap
+++ b/tasks/build/__snapshots__/build_action.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`build_action calling create_build rejects returned promise when build fails 1`] = `"foo bar"`;

--- a/tasks/build/build_action.js
+++ b/tasks/build/build_action.js
@@ -35,9 +35,6 @@ module.exports = function (plugin, run, options) {
     .then(function () {
       if (options.skipArchive) return;
       return createPackage(plugin, buildTarget, buildVersion);
-    })
-    .catch(function (err) {
-      console.log('BUILD ACTION FAILED:', err);
     });
 };
 

--- a/tasks/build/build_action.spec.js
+++ b/tasks/build/build_action.spec.js
@@ -86,5 +86,13 @@ describe('build_action', () => {
         options.files.forEach(file => expect(files).toContain(file));
       });
     });
+
+    it('rejects returned promise when build fails', () => {
+      mockBuild.mockImplementation(() => {
+        return Promise.reject(new Error('foo bar'));
+      });
+
+      return expect(buildAction(PLUGIN, noop)).rejects.toThrowErrorMatchingSnapshot();
+    });
   });
 });


### PR DESCRIPTION
Backports https://github.com/elastic/kibana/pull/17647 to 7.x

> When the plugin-helpers previously relied exclusively on synchronous tasks and therefore could rely on errors bubbling up and killing the process with an exit code of 1. Now that the build task is async failures in the build task are not reported to the CLI (except with a log message) or consumers of the promise returned from pluginHelpers.run('build').
> 
> This change ensures that the build task returns a promise and rejects that promise when the build fails, and also updates the plugin-helpers CLI to explicitly set the exitCode to 1 when a task fails.