### PR TITLE
[plugin-helpers] fix order of arguments passed to command actions

### DIFF
--- a/lib/__snapshots__/commander_action.spec.js.snap
+++ b/lib/__snapshots__/commander_action.spec.js.snap
@@ -30,11 +30,12 @@ Array [
     "taskName",
     Object {
       "args": Array [
+        "f",
+        "a",
         "b",
         "c",
         "d",
         "e",
-        "f",
       ],
     },
   ],

--- a/lib/commander_action.js
+++ b/lib/commander_action.js
@@ -1,10 +1,13 @@
 const run = require('./run');
 
 module.exports = function createCommanderAction(taskName, getOptions = () => {}) {
-  return (command, ...args) => {
+  return (...args) => {
+    // command is the last arg passed by commander, but we move it to the front of the list
+    const command = args.pop();
+
     return Promise
       .resolve()
-      .then(() => run(taskName, getOptions(...args)))
+      .then(() => run(taskName, getOptions(command, ...args)))
       .catch((error) => {
         process.stderr.write(`Task "${taskName}" failed:\n\n${error.stack || error.message}\n`);
         process.exit(1);


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana-plugin-helpers/issues/70

The arguments passed to commander actions was not ported from [the previous implementation](https://github.com/elastic/kibana-plugin-helpers/blob/792ede94f357fa2fa2ffc4593f8279c8373fc514/cli.js#L9-L13) properly, causing the first argument to be lost and the command to not be passed to `getOptions()` for some commands.

This fixes the issue and adds a comment for future devs to highlight what might not be super obvious about the implementation.